### PR TITLE
Fix beam comparator

### DIFF
--- a/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/FilamentStacker.java
+++ b/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/FilamentStacker.java
@@ -13,6 +13,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -60,8 +61,12 @@ public class FilamentStacker {
     return optimizeColorSequence(targetColor, emptyList());
   }
 
+  private static final Comparator<BeamEntry> BEAM_ENTRY_COMPARATOR =
+      comparingDouble(BeamEntry::getDifferenceFromTarget)
+          .thenComparing(entry -> String.join(",", entry.getFilamentSequence()));
+
   private TreeSet<BeamEntry> initializeBeam(RGBColor targetColor, List<String> topColors) {
-    TreeSet<BeamEntry> beam = new TreeSet<>(comparingDouble(BeamEntry::getDifferenceFromTarget));
+    TreeSet<BeamEntry> beam = new TreeSet<>(BEAM_ENTRY_COMPARATOR);
     // Start off the beam with 1 layer of each filament.
     for (Entry<String, FilamentData> filamentDataEntry : filamentData.entrySet()) {
       String filament = filamentDataEntry.getKey();

--- a/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/PalettePicker.java
+++ b/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/PalettePicker.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Comparator;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -98,8 +99,13 @@ public class PalettePicker {
     double differenceScore = Double.MAX_VALUE;
   }
 
+  private static final Comparator<Palette> PALETTE_COMPARATOR =
+      comparingDouble(Palette::getDifferenceScore)
+          .thenComparing(
+              palette -> String.join(",", new TreeSet<>(palette.getFilaments())));
+
   public ImmutableList<Palette> getBestPalettes(int countToReturn) {
-    TreeSet<Palette> paletteBeam = new TreeSet<>(comparingDouble(Palette::getDifferenceScore));
+    TreeSet<Palette> paletteBeam = new TreeSet<>(PALETTE_COMPARATOR);
 
     try (ProgressBar progressBar = new ProgressBar("Evaluating palettes", numConcurrentFilaments)) {
       filamentKeys.stream()

--- a/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/PalettePickerTest.java
+++ b/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/PalettePickerTest.java
@@ -1,0 +1,38 @@
+package net.bluevine.chromagica.imageto3dprint;
+
+import static net.bluevine.chromagica.imageto3dprint.TestData.TEST_FILAMENT_DATA_MAP;
+import static net.bluevine.chromagica.imageto3dprint.TestData.WHITE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import net.bluevine.chromagica.imageto3dprint.PalettePicker.Palette;
+import org.junit.jupiter.api.Test;
+
+class PalettePickerTest {
+  @Test
+  void getBestPalettes_simple() {
+    BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+    image.setRGB(0, 0, Color.WHITE.getRGB());
+
+    PalettePicker picker =
+        new PalettePicker(
+            TEST_FILAMENT_DATA_MAP,
+            2,
+            1,
+            WHITE_NAME,
+            List.of(),
+            List.of(),
+            image);
+
+    ImmutableList<Palette> palettes = picker.getBestPalettes(2);
+
+    assertEquals(2, palettes.size());
+    assertEquals(ImmutableList.of("Blue", "White"),
+        ImmutableList.sortedCopyOf(palettes.get(0).getFilaments()));
+    assertEquals(ImmutableList.of("Cyan", "White"),
+        ImmutableList.sortedCopyOf(palettes.get(1).getFilaments()));
+  }
+}


### PR DESCRIPTION
## Summary
- avoid duplicate entries in `FilamentStacker` beam search
- ensure `PalettePicker` beam handles ties consistently

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840ed12fa3c8320b80afa521ab3376a