### PR TITLE
build: Upgrade commons-math3 to 3.6.1

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'com.google.guava:guava:33.2.1-jre'
 
     implementation 'org.apache.commons:commons-imaging:1.0.0-alpha5'
-    implementation 'org.apache.commons:commons-math3:3.6'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
 }

--- a/loadstepwedge/build.gradle
+++ b/loadstepwedge/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'me.tongfei:progressbar:0.10.1'
 
     implementation 'org.apache.commons:commons-lang3:3.15.0'
-    implementation 'org.apache.commons:commons-math3:3.6'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
     testImplementation 'org.hamcrest:hamcrest:2.2'


### PR DESCRIPTION
This PR upgrades commons-math3 to version 3.6.1.