### PR TITLE
refactor: Remove suppressed warnings (take 2)

### DIFF
--- a/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/FilamentStacker.java
+++ b/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/FilamentStacker.java
@@ -136,12 +136,17 @@ public class FilamentStacker {
         .build();
   }
 
-  private final Cache<List<String>, RGBColor> colorCache =
-      CacheBuilder.newBuilder().maximumSize(1000).build();
+  static final int PERMUTATION_CACHE_SIZE = 1000;
+  private Cache<List<String>, RGBColor> permutationCache =
+      CacheBuilder.newBuilder().maximumSize(PERMUTATION_CACHE_SIZE).build();
+
+  void setPermutationCache(Cache<List<String>, RGBColor> permutationCache) {
+    this.permutationCache = permutationCache;
+  }
 
   private RGBColor getCachedColorForSequence(List<String> sequence) {
     try {
-      return colorCache.get(
+      return permutationCache.get(
           sequence, () -> getColorForSequence(sequence, filamentData, baseFilament));
     } catch (ExecutionException e) {
       throw new RuntimeException(e.getCause());

--- a/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/PalettePicker.java
+++ b/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/PalettePicker.java
@@ -24,7 +24,9 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import me.tongfei.progressbar.ProgressBar;
 import net.bluevine.chromagica.common.ColorUtil;
 import net.bluevine.chromagica.common.model.FilamentData;
@@ -91,8 +93,9 @@ public class PalettePicker {
     dominantColors = ColorUtil.getDominantColors(pixelColors, IMAGE_CLUSTERS);
   }
 
-  @Data
-  @SuppressWarnings("unused")
+  @Getter
+  @Setter
+  @RequiredArgsConstructor
   public static class Palette {
     final String baseFilament;
     final Set<String> filaments;

--- a/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/PalettePicker.java
+++ b/imageto3dprint/src/main/java/net/bluevine/chromagica/imageto3dprint/PalettePicker.java
@@ -24,9 +24,7 @@ import java.util.TreeSet;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import lombok.Data;
 import me.tongfei.progressbar.ProgressBar;
 import net.bluevine.chromagica.common.ColorUtil;
 import net.bluevine.chromagica.common.model.FilamentData;
@@ -93,9 +91,8 @@ public class PalettePicker {
     dominantColors = ColorUtil.getDominantColors(pixelColors, IMAGE_CLUSTERS);
   }
 
-  @Getter
-  @Setter
-  @RequiredArgsConstructor
+  @Data
+  @SuppressWarnings("unused")
   public static class Palette {
     final String baseFilament;
     final Set<String> filaments;

--- a/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/FilamentStackerTest.java
+++ b/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/FilamentStackerTest.java
@@ -74,12 +74,11 @@ class FilamentStackerTest {
     assertEquals(List.of("White", "Blue", "White", "Cyan"), result.getFilamentSequence());
   }
 
-  @SuppressWarnings("rawtypes,unchecked")
   @Test
   void optimizeColorSequence_cacheException() throws Exception {
     try (MockedStatic<CacheBuilder> mockedCacheBuilder = mockStatic(CacheBuilder.class)) {
       Cache<List<String>, RGBColor> mockedCache = mock(Cache.class);
-      CacheBuilder<List<String>, RGBColor> cacheBuilder = mock(CacheBuilder.class);
+      CacheBuilder<?, ?> cacheBuilder = mock(CacheBuilder.class);
       Mockito.when(cacheBuilder.maximumSize(anyLong())).thenReturn(cacheBuilder);
       Mockito.when(cacheBuilder.build()).thenReturn(mockedCache);
       mockedCacheBuilder.when(CacheBuilder::newBuilder).thenReturn(cacheBuilder);

--- a/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/FilamentStackerTest.java
+++ b/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/FilamentStackerTest.java
@@ -74,11 +74,12 @@ class FilamentStackerTest {
     assertEquals(List.of("White", "Blue", "White", "Cyan"), result.getFilamentSequence());
   }
 
+  @SuppressWarnings("rawtypes,unchecked")
   @Test
   void optimizeColorSequence_cacheException() throws Exception {
     try (MockedStatic<CacheBuilder> mockedCacheBuilder = mockStatic(CacheBuilder.class)) {
       Cache<List<String>, RGBColor> mockedCache = mock(Cache.class);
-      CacheBuilder<Object, Object> cacheBuilder = mock(CacheBuilder.class);
+      CacheBuilder<List<String>, RGBColor> cacheBuilder = mock(CacheBuilder.class);
       Mockito.when(cacheBuilder.maximumSize(anyLong())).thenReturn(cacheBuilder);
       Mockito.when(cacheBuilder.build()).thenReturn(mockedCache);
       mockedCacheBuilder.when(CacheBuilder::newBuilder).thenReturn(cacheBuilder);

--- a/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/FilamentStackerTest.java
+++ b/imageto3dprint/src/test/java/net/bluevine/chromagica/imageto3dprint/FilamentStackerTest.java
@@ -74,11 +74,12 @@ class FilamentStackerTest {
     assertEquals(List.of("White", "Blue", "White", "Cyan"), result.getFilamentSequence());
   }
 
+  @SuppressWarnings("rawtypes,unchecked")
   @Test
   void optimizeColorSequence_cacheException() throws Exception {
     try (MockedStatic<CacheBuilder> mockedCacheBuilder = mockStatic(CacheBuilder.class)) {
       Cache<List<String>, RGBColor> mockedCache = mock(Cache.class);
-      CacheBuilder<?, ?> cacheBuilder = mock(CacheBuilder.class);
+      CacheBuilder<List<String>, RGBColor> cacheBuilder = mock(CacheBuilder.class);
       Mockito.when(cacheBuilder.maximumSize(anyLong())).thenReturn(cacheBuilder);
       Mockito.when(cacheBuilder.build()).thenReturn(mockedCache);
       mockedCacheBuilder.when(CacheBuilder::newBuilder).thenReturn(cacheBuilder);


### PR DESCRIPTION
This PR removes suppressed warnings in PalettePicker.java and FilamentStackerTest.java. Fixes #8 and #9.